### PR TITLE
fix: リトライ処理を削除

### DIFF
--- a/src/app/_containers/supplement_list/container.tsx
+++ b/src/app/_containers/supplement_list/container.tsx
@@ -16,43 +16,11 @@ export default async function SupplementList() {
   );
 }
 
-async function checkConnection(): Promise<boolean> {
-  const controller = new AbortController();
-  try {
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => {
-        controller.abort();
-      }, 5000);
-    });
-
-    const fetchPromise = fetch(`${BACKEND_API_URL}/`, {
-      signal: controller.signal,
-      next: { revalidate: 0 },
-    });
-
-    await Promise.race([fetchPromise, timeoutPromise]);
-    return true;
-  } catch (error) {
-    if (error instanceof Error) {
-      console.error(`Backend health check failed: ${error.message}`);
-    }
-    return false;
-  }
-}
-
 async function SupplementListContainer() {
   const response = await retry(
     async () => {
-      // ヘルスチェックで準備状態を確認
-      const isAvailable = await checkConnection();
-      if (!isAvailable) {
-        console.log("Backend is not ready yet, retrying...");
-        throw new Error("Backend not ready");
-      }
-
-      // バックエンドの準備が確認できたら実際のデータを取得
       const res = await fetch(`${BACKEND_API_URL}/api/supplements`, {
-        cache: "no-store",
+        next: { revalidate: 30 },
       });
 
       if (!res.ok) {

--- a/src/app/_containers/supplement_list/container.tsx
+++ b/src/app/_containers/supplement_list/container.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import type { Supplement } from "@/app/_types/types";
 import retry from "async-retry";
 import { Suspense } from "react";
@@ -41,7 +43,7 @@ async function checkConnection(): Promise<boolean> {
     return false;
   }
 }
-export const dynamic = "force-dynamic";
+
 async function SupplementListContainer() {
   const response = await retry(
     async () => {

--- a/src/app/_containers/supplement_list/container.tsx
+++ b/src/app/_containers/supplement_list/container.tsx
@@ -23,14 +23,17 @@ async function checkConnection(): Promise<boolean> {
       setTimeout(() => {
         controller.abort();
         reject(new Error("Connection timeout"));
-      }, 3000); // タイムアウト時間を3秒に延長
+      }, 5000); // タイムアウトを5秒に延長
     });
 
     const fetchPromise = fetch(`${BACKEND_API_URL}/`, {
       signal: controller.signal,
+      headers: {
+        Connection: "keep-alive",
+      },
+      next: { revalidate: 0 },
     });
 
-    // Promise.raceの戻り値の型を明示的に指定
     const response = (await Promise.race([
       fetchPromise,
       timeoutPromise,


### PR DESCRIPTION
## Sammary
バックエンドのコールドスタートに対応できるようなリトライ処理をいろいろ試してみたが、どうしても初回表示でエラーになってしまうため、再検証時間を短くしたData Cacheを有効にすることに。

## Details


## Motivation